### PR TITLE
Add reward shaping wrapper and comparison training scripts

### DIFF
--- a/dual_train.py
+++ b/dual_train.py
@@ -1,0 +1,116 @@
+"""Dual-agent training script comparing baseline and reward shaped PPO agents.
+
+The script trains two agents on the Pokémon Red Gym environment.  Agent A uses
+only the sparse environment reward while Agent B receives additional shaped
+reward via :class:`ShapingTrainer`.  Episode statistics (return, length and
+success flag) are written to CSV files in the specified results directory.
+
+Example
+-------
+$ python dual_train.py --total_timesteps 10000 --seed 42 \
+    --shaping_config shaping.yaml --output results
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Callable, Optional
+
+import gymnasium as gym
+import numpy as np
+import pandas as pd
+from stable_baselines3 import PPO
+from stable_baselines3.common.callbacks import BaseCallback
+from stable_baselines3.common.env_util import make_vec_env
+from stable_baselines3.common.monitor import Monitor
+
+from baselines.shaping_trainer import ShapingTrainer
+from shaping_reward_wrapper import ShapingRewardWrapper
+
+# ---------------------------------------------------------------------------
+class EpisodeLogger(BaseCallback):
+    """Collect per-episode statistics and write them to a CSV file."""
+
+    def __init__(self, csv_path: Path):
+        super().__init__()
+        self.csv_path = csv_path
+        self.rows = []
+
+    def _on_step(self) -> bool:  # type: ignore[override]
+        info = self.locals.get("infos", [{}])[0]
+        if "episode" in info:
+            ep = info["episode"]
+            row = {
+                "reward": ep.get("r", 0.0),
+                "length": ep.get("l", 0),
+                "success": int(info.get("badge_obtained", False)),
+            }
+            self.rows.append(row)
+        return True
+
+    def _on_training_end(self) -> None:  # type: ignore[override]
+        if self.rows:
+            df = pd.DataFrame(self.rows)
+            self.csv_path.parent.mkdir(parents=True, exist_ok=True)
+            df.to_csv(self.csv_path, index=False)
+
+
+# ---------------------------------------------------------------------------
+def make_env_fn(env_id: str, *, seed: int, trainer: Optional[ShapingTrainer] = None) -> Callable[[], gym.Env]:
+    """Create an environment factory respecting the given seed and wrapper."""
+
+    def _init() -> gym.Env:
+        env = gym.make(env_id)
+        env.reset(seed=seed)
+        env.action_space.seed(seed)
+        if trainer is not None:
+            env = ShapingRewardWrapper(env, trainer)
+        return Monitor(env)
+
+    return _init
+
+
+# ---------------------------------------------------------------------------
+def train_single(env_fn: Callable[[], gym.Env], total_timesteps: int, seed: int, csv_file: Path) -> None:
+    """Train a PPO agent and log per-episode statistics."""
+
+    env = make_vec_env(env_fn, n_envs=1, seed=seed)
+    model = PPO("CnnPolicy", env, seed=seed, verbose=0)
+    callback = EpisodeLogger(csv_file)
+    model.learn(total_timesteps=total_timesteps, callback=callback)
+    env.close()
+
+
+# ---------------------------------------------------------------------------
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed", type=int, default=0, help="Random seed")
+    parser.add_argument("--total_timesteps", type=int, default=1000, help="Training steps per agent")
+    parser.add_argument("--output", type=Path, default=Path("results"), help="Directory to store results")
+    parser.add_argument("--shaping_config", type=Path, help="YAML config for reward shaping")
+    parser.add_argument(
+        "--reward_type",
+        choices=["baseline", "shaping", "both"],
+        default="both",
+        help="Which agents to train",
+    )
+    parser.add_argument("--env_id", default="PokemonRed-v0", help="Gym environment id")
+    args = parser.parse_args()
+
+    np.random.seed(args.seed)
+
+    baseline_csv = args.output / "baseline_rewards.csv"
+    shaping_csv = args.output / "shaping_rewards.csv"
+
+    if args.reward_type in {"baseline", "both"}:
+        env_fn = make_env_fn(args.env_id, seed=args.seed)
+        train_single(env_fn, args.total_timesteps, args.seed, baseline_csv)
+
+    if args.reward_type in {"shaping", "both"}:
+        trainer = ShapingTrainer.from_config(args.shaping_config)
+        env_fn = make_env_fn(args.env_id, seed=args.seed, trainer=trainer)
+        train_single(env_fn, args.total_timesteps, args.seed, shaping_csv)
+
+
+if __name__ == "__main__":
+    main()

--- a/plot_results.py
+++ b/plot_results.py
@@ -1,0 +1,75 @@
+"""Visualise baseline vs reward-shaped training results.
+
+Reads the CSV logs produced by :mod:`dual_train` and creates comparison plots
+showing raw episode returns, rolling average returns and success rates.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+
+def load_csv(path: Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    df.index.name = "episode"
+    return df
+
+
+def plot(df_base: pd.DataFrame, df_shape: pd.DataFrame, out_dir: Path) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Total reward per episode
+    plt.figure()
+    plt.plot(df_base.index, df_base["reward"], label="Baseline")
+    plt.plot(df_shape.index, df_shape["reward"], label="Shaping")
+    plt.xlabel("Episode")
+    plt.ylabel("Total reward")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(out_dir / "episode_rewards.png")
+    plt.close()
+
+    # Rolling average reward
+    roll_base = df_base["reward"].rolling(100, min_periods=1).mean()
+    roll_shape = df_shape["reward"].rolling(100, min_periods=1).mean()
+    plt.figure()
+    plt.plot(roll_base, label="Baseline")
+    plt.plot(roll_shape, label="Shaping")
+    plt.xlabel("Episode")
+    plt.ylabel("Rolling avg reward (100 ep)")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(out_dir / "rolling_reward.png")
+    plt.close()
+
+    # Success rate
+    succ_base = df_base["success"].rolling(100, min_periods=1).mean()
+    succ_shape = df_shape["success"].rolling(100, min_periods=1).mean()
+    plt.figure()
+    plt.plot(succ_base, label="Baseline")
+    plt.plot(succ_shape, label="Shaping")
+    plt.xlabel("Episode")
+    plt.ylabel("Success rate")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(out_dir / "success_rate.png")
+    plt.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--results", type=Path, default=Path("results"), help="Directory containing CSV logs")
+    args = parser.parse_args()
+
+    base_csv = args.results / "baseline_rewards.csv"
+    shape_csv = args.results / "shaping_rewards.csv"
+    df_base = load_csv(base_csv)
+    df_shape = load_csv(shape_csv)
+    plot(df_base, df_shape, args.results / "plots")
+
+
+if __name__ == "__main__":
+    main()

--- a/shaping_reward_wrapper.py
+++ b/shaping_reward_wrapper.py
@@ -1,0 +1,63 @@
+"""Reward shaping wrapper for Pokémon Red Gym environments.
+
+This module defines :class:`ShapingRewardWrapper`, a thin :mod:`gymnasium`
+wrapper that augments or replaces the environment reward using a
+:class:`baselines.shaping_trainer.ShapingTrainer` instance.  The trainer looks at
+information provided by the environment via the ``info`` dictionary and computes
+additional reward components with optional decay and recovery dynamics.
+
+Usage
+-----
+>>> from baselines.shaping_trainer import ShapingTrainer
+>>> from shaping_reward_wrapper import ShapingRewardWrapper
+>>> trainer = ShapingTrainer.from_config("shaping_config.yaml")
+>>> env = ShapingRewardWrapper(gym.make("SomeEnv"), trainer)
+
+The wrapper calls ``trainer.reset_episode()`` on ``reset`` and combines the
+returned shaped reward with the environment's reward on each ``step``.
+"""
+from __future__ import annotations
+
+from typing import Any, Tuple
+
+import gymnasium as gym
+
+from baselines.shaping_trainer import ShapingTrainer
+
+
+class ShapingRewardWrapper(gym.Wrapper):
+    """Apply :class:`ShapingTrainer` rewards to an environment.
+
+    Parameters
+    ----------
+    env:
+        The environment to wrap.
+    trainer:
+        Instance of :class:`ShapingTrainer` providing shaped reward values.
+    replace_reward:
+        If ``True`` the environment's reward is ignored and the shaped reward is
+        returned instead.  Otherwise the shaped reward is added to the original
+        reward (default behaviour).
+    """
+
+    def __init__(self, env: gym.Env, trainer: ShapingTrainer, *, replace_reward: bool = False) -> None:
+        super().__init__(env)
+        self.trainer = trainer
+        self.replace_reward = replace_reward
+
+    # ------------------------------------------------------------------
+    def reset(self, **kwargs: Any) -> Tuple[Any, dict]:
+        """Reset the environment and internal trainer state."""
+        self.trainer.reset_episode()
+        return self.env.reset(**kwargs)
+
+    # ------------------------------------------------------------------
+    def step(self, action: Any) -> Tuple[Any, float, bool, bool, dict]:
+        """Augment rewards with shaped values on every environment step."""
+        obs, reward, terminated, truncated, info = self.env.step(action)
+        shaped = self.trainer.get_shaped_reward(info)
+        reward = shaped if self.replace_reward else reward + shaped
+        return obs, reward, terminated, truncated, info
+
+
+__all__ = ["ShapingRewardWrapper"]


### PR DESCRIPTION
## Summary
- Implement `ShapingRewardWrapper` to augment environment rewards via `ShapingTrainer`.
- Add `dual_train.py` to train baseline and shaped PPO agents and log episode metrics.
- Add `plot_results.py` to visualise total reward, rolling averages and success rates.

## Testing
- `python -m py_compile shaping_reward_wrapper.py dual_train.py plot_results.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbd80b21688326b48735491422cd37