### PR TITLE
Enable shaping rewards in v2 training pipeline

### DIFF
--- a/v2/config/shaping_rewards.yaml
+++ b/v2/config/shaping_rewards.yaml
@@ -1,0 +1,23 @@
+shaping_units:
+  - name: event
+    base_reward: 1.0
+    decay_trigger: 10
+    decay_rate: 0.5
+    recovery_trigger: 50
+    recovery_multiplier: 2.0
+  - name: heal
+    base_reward: 0.5
+    decay_trigger: 5
+    decay_rate: 0.5
+    recovery_trigger: 20
+    recovery_multiplier: 2.0
+  - name: badge
+    base_reward: 5.0
+  - name: explore
+    base_reward: 0.1
+    decay_trigger: 100
+    decay_rate: 0.5
+    recovery_trigger: 200
+    recovery_multiplier: 2.0
+  - name: stuck
+    base_reward: -0.05

--- a/v2/shaping_trainer.py
+++ b/v2/shaping_trainer.py
@@ -1,0 +1,163 @@
+"""Shaping-based reward trainer for Pokemon Red Gym environments.
+
+This module defines :class:`ShapingTrainer` which computes shaped rewards from
+environment ``info`` dictionaries. Rewards for individual behaviours (shaping
+units) decay once the behaviour has been repeatedly mastered and recover if the
+behaviour is forgotten.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, Optional, Union, Any
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - fallback if yaml isn't installed
+    yaml = None  # type: ignore
+
+
+@dataclass
+class ShapingUnit:
+    """Configuration and state for a single shaping target.
+
+    Parameters
+    ----------
+    name:
+        Key expected in the environment ``info`` dict.
+    base_reward:
+        Initial reward for successfully performing the behaviour.
+    decay_trigger:
+        Number of consecutive successes before reward decays. ``None`` disables
+        decay.
+    recovery_trigger:
+        Number of consecutive failures before the behaviour's reward is
+        temporarily increased. ``None`` disables recovery.
+    decay_rate:
+        Multiplier applied to ``current_reward`` once ``decay_trigger`` is met.
+    recovery_multiplier:
+        Multiplier applied to ``base_reward`` when recovery is triggered.
+    min_reward:
+        Lower bound for ``current_reward`` after decays.
+    """
+
+    name: str
+    base_reward: float
+    decay_trigger: Optional[int] = None
+    recovery_trigger: Optional[int] = None
+    decay_rate: float = 1.0
+    recovery_multiplier: float = 1.0
+    min_reward: float = 0.0
+
+    # Runtime state
+    current_reward: float = field(init=False)
+    success_count: int = field(default=0, init=False)
+    failure_count: int = field(default=0, init=False)
+    _temp_reward: Optional[float] = field(default=None, init=False)
+
+    def __post_init__(self) -> None:
+        self.current_reward = self.base_reward
+
+    # ------------------------------------------------------------------
+    def reset_episode(self) -> None:
+        """Reset per-episode counters while keeping learned reward values."""
+        self.success_count = 0
+        self.failure_count = 0
+        self._temp_reward = None
+
+    # ------------------------------------------------------------------
+    def _apply_decay(self) -> None:
+        if self.decay_trigger is not None and self.success_count >= self.decay_trigger:
+            self.current_reward = max(self.min_reward, self.current_reward * self.decay_rate)
+            self.success_count = 0
+
+    # ------------------------------------------------------------------
+    def _apply_recovery(self) -> None:
+        if self.recovery_trigger is not None and self.failure_count >= self.recovery_trigger:
+            self._temp_reward = self.base_reward * self.recovery_multiplier
+            self.failure_count = 0
+
+    # ------------------------------------------------------------------
+    def update(self, active: bool) -> float:
+        """Update success/failure counters and return reward contribution.
+
+        Parameters
+        ----------
+        active:
+            ``True`` if the environment ``info`` contains this unit's ``name``
+            and the value is truthy.
+        """
+
+        if active:
+            reward = self._temp_reward if self._temp_reward is not None else self.current_reward
+            # success handling
+            self.success_count += 1
+            self.failure_count = 0
+            self._temp_reward = None
+            self._apply_decay()
+            return reward
+        else:
+            # failure handling
+            self.failure_count += 1
+            self._apply_recovery()
+            return 0.0
+
+
+class ShapingTrainer:
+    """Applies shaping logic to environment ``info`` dictionaries."""
+
+    def __init__(self, units: Iterable[ShapingUnit]):
+        self.units: Dict[str, ShapingUnit] = {u.name: u for u in units}
+
+    # ------------------------------------------------------------------
+    def reset_episode(self) -> None:
+        """Reset per-episode counters for all shaping units."""
+        for unit in self.units.values():
+            unit.reset_episode()
+
+    # ------------------------------------------------------------------
+    def get_shaped_reward(self, info: Mapping[str, Any]) -> float:
+        """Compute reward from the provided environment ``info`` dictionary."""
+        total = 0.0
+        for name, unit in self.units.items():
+            active = bool(info.get(name))
+            total += unit.update(active)
+        return total
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_config(cls, config: Union[str, Path, Mapping[str, Any]]) -> "ShapingTrainer":
+        """Create a trainer from a YAML file path or a configuration dict."""
+
+        if isinstance(config, (str, Path)):
+            if yaml is None:
+                raise ImportError("PyYAML is required to load configuration from a file")
+            with open(config, "r", encoding="utf-8") as fh:
+                cfg_dict = yaml.safe_load(fh)
+        elif isinstance(config, Mapping):
+            cfg_dict = config
+        else:  # pragma: no cover - defensive programming
+            raise TypeError("config must be a path or mapping")
+
+        units_cfg = cfg_dict.get("shaping_units", [])
+        units = []
+        for unit_cfg in units_cfg:
+            base_reward = unit_cfg.get("base_reward")
+            if base_reward is None:
+                base_reward = unit_cfg.get("reward")  # backward compatibility
+            unit = ShapingUnit(
+                name=unit_cfg["name"],
+                base_reward=float(base_reward),
+                decay_trigger=unit_cfg.get("decay_trigger"),
+                recovery_trigger=unit_cfg.get("recovery_trigger"),
+                decay_rate=unit_cfg.get("decay_rate", 1.0),
+                recovery_multiplier=unit_cfg.get("recovery_multiplier", 1.0),
+                min_reward=unit_cfg.get("min_reward", 0.0),
+            )
+            units.append(unit)
+
+        return cls(units)
+
+
+__all__ = ["ShapingTrainer", "ShapingUnit"]

--- a/v2/train.py
+++ b/v2/train.py
@@ -1,0 +1,149 @@
+import sys
+import argparse
+from os.path import exists
+from pathlib import Path
+
+from red_gym_env_v2 import RedGymEnv
+from stream_agent_wrapper import StreamWrapper
+from shaping_trainer import ShapingTrainer
+from stable_baselines3 import PPO
+from stable_baselines3.common import env_checker
+from stable_baselines3.common.vec_env import SubprocVecEnv
+from stable_baselines3.common.utils import set_random_seed
+from stable_baselines3.common.callbacks import CheckpointCallback, CallbackList
+from tensorboard_callback import TensorboardCallback
+
+
+def make_env(rank, env_conf, seed=0):
+    """Utility function for multiprocessed env."""
+
+    def _init():
+        trainer = None
+        if env_conf.get("reward_type") == "shaping":
+            trainer = ShapingTrainer.from_config(env_conf["shaping_config"])
+        env = StreamWrapper(
+            RedGymEnv(env_conf, trainer),
+            stream_metadata={
+                "user": "v2-default",
+                "env_id": rank,
+                "color": "#447799",
+                "extra": "",
+            },
+        )
+        env.reset(seed=(seed + rank))
+        return env
+
+    set_random_seed(seed)
+    return _init
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--reward_type",
+        choices=["baseline", "shaping"],
+        default="baseline",
+        help="Use shaping rewards or baseline rewards",
+    )
+    parser.add_argument(
+        "--shaping_config",
+        default=str(Path(__file__).parent / "config" / "shaping_rewards.yaml"),
+        help="Path to shaping reward configuration file",
+    )
+    args = parser.parse_args()
+
+    use_wandb_logging = False
+    ep_length = 2048 * 80
+    sess_id = "runs"
+    sess_path = Path(sess_id)
+
+    env_config = {
+        "headless": True,
+        "save_final_state": False,
+        "early_stop": False,
+        "action_freq": 24,
+        "init_state": "../init.state",
+        "max_steps": ep_length,
+        "print_rewards": True,
+        "save_video": False,
+        "fast_video": True,
+        "session_path": sess_path,
+        "gb_path": "../PokemonRed.gb",
+        "debug": False,
+        "reward_scale": 0.5,
+        "explore_weight": 0.25,
+        "reward_type": args.reward_type,
+        "shaping_config": args.shaping_config,
+    }
+
+    print(env_config)
+
+    num_cpu = 64
+    env = SubprocVecEnv([make_env(i, env_config) for i in range(num_cpu)])
+
+    checkpoint_callback = CheckpointCallback(
+        save_freq=ep_length // 2, save_path=sess_path, name_prefix="poke"
+    )
+
+    callbacks = [checkpoint_callback, TensorboardCallback(sess_path)]
+
+    if use_wandb_logging:
+        import wandb
+        from wandb.integration.sb3 import WandbCallback
+
+        wandb.tensorboard.patch(root_logdir=str(sess_path))
+        run = wandb.init(
+            project="pokemon-train",
+            id=sess_id,
+            name="v2-a",
+            config=env_config,
+            sync_tensorboard=True,
+            monitor_gym=True,
+            save_code=True,
+        )
+        callbacks.append(WandbCallback())
+
+    #env_checker.check_env(env)
+
+    if sys.stdin.isatty():
+        file_name = ""
+    else:
+        file_name = sys.stdin.read().strip()
+
+    train_steps_batch = ep_length // 64
+
+    if exists(file_name + ".zip"):
+        print("\nloading checkpoint")
+        model = PPO.load(file_name, env=env)
+        model.n_steps = train_steps_batch
+        model.n_envs = num_cpu
+        model.rollout_buffer.buffer_size = train_steps_batch
+        model.rollout_buffer.n_envs = num_cpu
+        model.rollout_buffer.reset()
+    else:
+        model = PPO(
+            "MultiInputPolicy",
+            env,
+            verbose=1,
+            n_steps=train_steps_batch,
+            batch_size=512,
+            n_epochs=1,
+            gamma=0.997,
+            ent_coef=0.01,
+            tensorboard_log=sess_path,
+        )
+
+    print(model.policy)
+
+    model.learn(
+        total_timesteps=(ep_length) * num_cpu * 10000,
+        callback=CallbackList(callbacks),
+        tb_log_name="poke_ppo",
+    )
+
+    if use_wandb_logging:
+        run.finish()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add configurable shaping rewards to v2 training via `--reward_type`
- expose ShapingTrainer in `RedGymEnv` and compute shaped rewards
- include default shaping reward configuration

## Testing
- `python -m py_compile v2/train.py v2/red_gym_env_v2.py v2/shaping_trainer.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbd8f76de48326977d82ec4c389bbe